### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
 # Changelog
 
 <!-- scriv-insert-here -->
+
+<a id='changelog-0.2.0'></a>
+# 0.2.0 — 2026-08-07
+
+## Changed
+
+- Adopt the shared Copier project template for packaging, CI, releases,
+  documentation, and development tooling.

--- a/changelog.d/20260807_092000_frank_hoffmann.md
+++ b/changelog.d/20260807_092000_frank_hoffmann.md
@@ -1,4 +1,0 @@
-### Changed
-
-- Adopt the shared Copier project template for packaging, CI, releases,
-  documentation, and development tooling.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ license = "MIT"
 name = "format-dedent"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "0.1.1"
+version = "0.2.0"
 
 [dependency-groups]
 cog = [

--- a/uv.lock
+++ b/uv.lock
@@ -745,7 +745,7 @@ wheels = [
 
 [[package]]
 name = "format-dedent"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Prepare release v0.2.0.

This pull request was generated from the changelog fragments and
Conventional Commits on `main`.